### PR TITLE
Fixed issue #4 and fixed hex conversion issue

### DIFF
--- a/color2color.js
+++ b/color2color.js
@@ -173,10 +173,11 @@ IndyArmy Network, Inc.
 				a : parseFloat( bits[ 4 ] )
 			};
 			if ( hsl.s === 0 ) {
+				var v = parseInt(Math.round(255*hsl.l));
 				rgba = {
-					r : hsl.l,
-					g : hsl.l,
-					b : hsl.l,
+					r : v,
+					g : v,
+					b : v,
 					a : hsl.a
 				};
 			} else {


### PR DESCRIPTION
1fe7ed0 - For the hex issue, when converting to hex, it was not returning the proper two character for r,g, and b for single characters.
Ex. color2color('red','hex') will return '#ff00' which is incorrect. It should be '#ff0000'.

8ad9627 - when converting HSL and (S)Saturation is zero, it was doing the wrong conversion. L(Lightness) is not the RGB values, you have to multiple to percentage by 255 to get their values.
Ex. color2color('hsl(0,0%,99%') will return 'rgba(0.99,0.99,0.99,1)' which is incorrect. It should be 'rgba(252,252,252,1)'
