### PR TITLE
Better RGB[A] and HSL[A] regexes

### DIFF
--- a/src/colorcolor.spec.ts
+++ b/src/colorcolor.spec.ts
@@ -8,6 +8,12 @@ describe('colorcolor', () => {
 		expect(colorcolor('hsla(208,100%,97.1%, 0.6)')).toEqual('rgba(240,248,255,0.6)');
 	});
 
+	it('reads valid CSS Color Name strings', () => {
+		expect(colorcolor('AliceBlue')).toEqual('rgba(240,248,255,1)')
+		expect(colorcolor('RebeccaPurple')).toEqual('rgba(102,51,153,1)')
+		expect(colorcolor('transparent')).toEqual('rgba(255,255,255,0)')
+	});
+
 	it('reads valid HSL strings', () => {
 		expect(colorcolor('hsl(0.35turn, 75%, 90%)')).toEqual('rgba(210,249,214,1)');
 		expect(colorcolor('hsl(1.5rad 75% 90%)')).toEqual('rgba(232,249,210,1)');

--- a/src/colorcolor.spec.ts
+++ b/src/colorcolor.spec.ts
@@ -8,6 +8,22 @@ describe('colorcolor', () => {
 		expect(colorcolor('hsla(208,100%,97.1%, 0.6)')).toEqual('rgba(240,248,255,0.6)');
 	});
 
+	it('reads valid RGB strings', () => {
+		expect(colorcolor('rgb(220, 254, 237)')).toEqual('rgba(220,254,237,1)');
+		expect(colorcolor('rgb(220.5, 254, 237)')).toEqual('rgba(220,254,237,1)');
+		expect(colorcolor('rgb(220  254  237)')).toEqual('rgba(220,254,237,1)');
+		expect(colorcolor('rgb(220.5  254  237)')).toEqual('rgba(220,254,237,1)');
+		expect(colorcolor('rgb(85%  99%  92.5%)')).toEqual('rgba(216,252,234,1)');
+	});
+
+	it('reads valid RGBA strings', () => {
+		expect(colorcolor('rgba(220, 254, 237, 0.5)')).toEqual('rgba(220,254,237,0.5)');
+		expect(colorcolor('rgba(220.5, 254, 237, 50%)')).toEqual('rgba(220,254,237,0.5)');
+		expect(colorcolor('rgba(220  254  237 / 0.75)')).toEqual('rgba(220,254,237,0.75)');
+		expect(colorcolor('rgba(220.5  254  237 / 75%)')).toEqual('rgba(220,254,237,0.75)');
+		expect(colorcolor('rgba(85%  99%  92.5% / 0.3)')).toEqual('rgba(216,252,234,0.3)');
+	});
+
 	it('calculates opacity', () => {
 		expect(colorcolor('#dfe', 'rgba', true)).toEqual('rgba(0,255,128,0.1333)');
 		expect(colorcolor('#dfe', 'rgba', false)).toEqual('rgba(221,255,238,1)');

--- a/src/colorcolor.spec.ts
+++ b/src/colorcolor.spec.ts
@@ -8,6 +8,20 @@ describe('colorcolor', () => {
 		expect(colorcolor('hsla(208,100%,97.1%, 0.6)')).toEqual('rgba(240,248,255,0.6)');
 	});
 
+	it('reads valid HSL strings', () => {
+		expect(colorcolor('hsl(0.35turn, 75%, 90%)')).toEqual('rgba(210,249,214,1)');
+		expect(colorcolor('hsl(1.5rad 75% 90%)')).toEqual('rgba(232,249,210,1)');
+		expect(colorcolor('hsl(200grad, 45.75%, 80.6667%)')).toEqual('rgba(183,228,228,1)');
+		expect(colorcolor('hsl(200 45.75% 80.6667%)')).toEqual('rgba(183,213,228,1)');
+	});
+
+	it('reads valid HSLA strings', () => {
+		expect(colorcolor('hsla(0.35turn, 75%, 90%, .75)')).toEqual('rgba(210,249,214,0.75)');
+		expect(colorcolor('hsla(1.5rad 75% 90% / 75%)')).toEqual('rgba(232,249,210,0.75)');
+		expect(colorcolor('hsla(200grad, 45.75%, 80.6667%, 75%)')).toEqual('rgba(183,228,228,0.75)');
+		expect(colorcolor('hsla(200 45.75% 80.6667% / 0.75)')).toEqual('rgba(183,213,228,0.75)');
+	});
+
 	it('reads valid RGB strings', () => {
 		expect(colorcolor('rgb(220, 254, 237)')).toEqual('rgba(220,254,237,1)');
 		expect(colorcolor('rgb(220.5, 254, 237)')).toEqual('rgba(220,254,237,1)');

--- a/src/colorcolor.ts
+++ b/src/colorcolor.ts
@@ -140,6 +140,7 @@ const namedColors = {
 	'teal': '#008080',
 	'thistle': '#d8bfd8',
 	'tomato': '#ff6347',
+	'transparent': '#fff0',
 	'turquoise': '#40e0d0',
 	'violet': '#ee82ee',
 	'wheat': '#f5deb3',

--- a/src/colorcolor.ts
+++ b/src/colorcolor.ts
@@ -760,7 +760,7 @@ const ColorDefinitions: ColorDefinitions = {
 		toRGBA: bits => {
 			const ConvertedBits = bits
 				.map(bit => bit.charAt(bit.length - 1) === '%' ? fromPercent(parseInt(bit, DecimalRadix), MaxRgbRange) - 1 : bit)
-				.map(bit => `${bit}`);
+				.map(bit => `${ bit }`);
 
 			return [
 				parseInt(ConvertedBits[RedIndex], DecimalRadix),
@@ -778,15 +778,16 @@ const ColorDefinitions: ColorDefinitions = {
 			'rgba(75%, 50%, 25%, 50%)',
 			'rgba(75%  50%  25% / 50%)',
 		],
+		// eslint-disable-next-line max-len
 		re: /^rgba\(\s*(\d{1,3}(?:\.\d+)?%?|\.\d+%?)[, ]\s*(\d{1,3}(?:\.\d+)?%?|\.\d+%?)[, ]\s*(\d{1,3}(?:\.\d+)?%?|\.\d+%?)[, ]\/?\s*(\d+(?:\.\d+)?%?|\.\d+%?)\s*\)$/,
 		toRGBA: bits => {
 			const ConvertedBits = bits
 				.map(bit => bit.charAt(bit.length - 1) === '%' ? fromPercent(parseInt(bit, DecimalRadix), MaxRgbRange) - 1 : bit)
-				.map(bit => `${bit}`);
+				.map(bit => `${ bit }`);
 
 			if (bits[AlphaIndex].charAt(bits[AlphaIndex].length - 1) === '%') {
 				// override so that the alpha channel is a float instead of an integer
-				ConvertedBits[AlphaIndex] = `${fromPercent(parseInt(bits[AlphaIndex], DecimalRadix), MaxOpacity)}`;
+				ConvertedBits[AlphaIndex] = `${ fromPercent(parseInt(bits[AlphaIndex], DecimalRadix), MaxOpacity) }`;
 			}
 
 			return [
@@ -813,7 +814,7 @@ const ColorDefinitions: ColorDefinitions = {
  * @param targetColor The CSS color type to convert to
  * @param calculateOpacity If the target color has an opacity value (HexA, HSLA, or RGBA), the result will be correct if viewed against a white background
  */
-export function colorcolor (
+export function colorcolor(
 	originalColor: string,
 	targetColor: ColorType = ColorName.RGBA,
 	calculateOpacity = false,
@@ -824,43 +825,59 @@ export function colorcolor (
 
 	switch (targetColor) {
 		case ColorName.HEX: {
-			const hex = (returnedComponent as Hex);
+			const hex = (
+				returnedComponent as Hex
+			);
 			returnedColor = `#${ hex.r }${ hex.g }${ hex.b }`;
 			break;
 		}
 		case ColorName.HEXA: {
-			const hexa = (returnedComponent as Hexa);
+			const hexa = (
+				returnedComponent as Hexa
+			);
 			returnedColor = `#${ hexa.r }${ hexa.g }${ hexa.b }${ hexa.a }`;
 			break;
 		}
 		case ColorName.HSB: {
-			const hsb = (returnedComponent as Hsb);
+			const hsb = (
+				returnedComponent as Hsb
+			);
 			returnedColor = `hsb(${ hsb.h },${ hsb.s }%,${ hsb.b }%)`;
 			break;
 		}
 		case ColorName.HSL: {
-			const hsl = (returnedComponent as Hsl);
+			const hsl = (
+				returnedComponent as Hsl
+			);
 			returnedColor = `hsl(${ hsl.h },${ hsl.s }%,${ hsl.l }%)`;
 			break;
 		}
 		case ColorName.HSLA: {
-			const hsl = (returnedComponent as Hsla);
+			const hsl = (
+				returnedComponent as Hsla
+			);
 			returnedColor = `hsla(${ hsl.h },${ hsl.s }%,${ hsl.l }%,${ hsl.a })`;
 			break;
 		}
 		case ColorName.HSV: {
-			const hsv = (returnedComponent as Hsv);
+			const hsv = (
+				returnedComponent as Hsv
+			);
 			returnedColor = `hsv(${ hsv.h },${ hsv.s }%,${ hsv.v }%)`;
 			break;
 		}
 		case ColorName.RGB: {
-			const rgb = (returnedComponent as Rgb);
+			const rgb = (
+				returnedComponent as Rgb
+			);
 			returnedColor = `rgb(${ rgb.r },${ rgb.g },${ rgb.b })`;
 			break;
 		}
 		case ColorName.RGBA:
 		default: {
-			const rgba = (returnedComponent as Rgba);
+			const rgba = (
+				returnedComponent as Rgba
+			);
 			returnedColor = `rgba(${ rgba.r },${ rgba.g },${ rgba.b },${ rgba.a })`;
 			break;
 		}


### PR DESCRIPTION
This updates the RGB and HSL detection to support both comma and space formats, as well as percentages. HSL also understands all valid angles for the first number, including `deg`, `grad`, `rad`, and `turn`.

These are all valid RGB[A] and HSL[A] strings:

* `rgb(100%, 50%, 25%)`
* `rgb(100% 50% 25%)`
* `rgb(255, 127, 36.5)`
* `rgb(255 127 36.5)`
* `rgba(85%, 55.25%, 40%, 75%)`
* `rgba(85% 55.25% 30% / 75%)`
* `rgba(200, 129, 45, 0.75)`
* `rgba(200 129 45 / 0.75)`
* `hsl(0.75turn, 75%, 50%)`
* `hsla(1.5rad 40% 75% / 0.5)`
* `hsla(1.5rad 40% 75% / 50%)`

Technically, for RGB[A], all the parameters need to be either percentages or numbers, but `colorcolor` doesn't care and you can mix and match if desired.