### PR TITLE
Add `type: module` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^4.8.4",
     "uglify-js": "^3.17.3"
   },
+  "type": "module",
   "dependencies": {
     "css-color-names": "^1.0.1"
   },


### PR DESCRIPTION
Fixes an issue where the code can't be used in ESM modules. I think? See https://github.com/fgnass/spin.js/issues/384.

```
SyntaxError: Unexpected token 'export'
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1088:15)
    at Module._compile (node:internal/modules/cjs/loader:1123:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:518:24)
```